### PR TITLE
Use another return code for "User already exist"

### DIFF
--- a/bin/manage_users
+++ b/bin/manage_users
@@ -39,7 +39,7 @@ async function createUser (argv) {
   // Cannot create already-existing users
   if (existingUser !== undefined) {
     console.log(`User with e-mail ${existingUser.email} already exists! Aborting ...`)
-    process.exit(1)
+    process.exit(2)
   }
 
   const pass = getPass(argv, 'add')


### PR DESCRIPTION
This allows external scripts differentiating between "failure" and "everything is fine"